### PR TITLE
Adding link to the slack plugin in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Note: Plugin folder is case-sensitive.
 Configuration
 -------------
 
-Firstly, you have to generate a new webhook url in Slack (**Configured Integrations > Incoming Webhook**).
+Firstly, you have to generate a new webhook url in Slack (**Configured Integrations > Incoming Webhook**) [from here](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks).
 
 You can define only one webhook url (**Settings > Integrations > Slack**) and override the channel for each project and user.
 


### PR DESCRIPTION
Adding link to the slack plugin in readme.md so that user can directly go there rather than search for it in slack.