### PR TITLE
use username and icon that defined in Slack

### DIFF
--- a/Notification/Slack.php
+++ b/Notification/Slack.php
@@ -88,9 +88,7 @@ class Slack extends Base implements NotificationInterface
         }
 
         return array(
-            'text' => $message,
-            'username' => 'Kanboard',
-            'icon_url' => 'https://raw.githubusercontent.com/kanboard/kanboard/master/assets/img/favicon.png',
+            'text' => $message
         );
     }
 


### PR DESCRIPTION
I deleted the `username` and `icon_url` to stop the overwrite on the Slack setting. Now when you want to define a webhook in Slack, you can define username and icon.